### PR TITLE
Update extension info for launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+Anyone should feel free to fork/PR this. Open source for the win!
+Please make sure and explain your changes thoroughly, update version and changelog where needed.
+
+_NOTE_: HubL tags, functions, expression tests and filters are all pulled from the `cos-rendering/v1/hubldoc` api, so do not update any `snippets/auto-gen/...` json files manually. Run `npm run generate` to re-generate these JSON files when HubL changes occur. `snippets/man_gen/...` files are for any extra/helpful snippets used in HubL - these files are maintained manually.
+
+### To run this extension locally:
+- `git clone` repo
+- Open this project in Visual Studio Code
+- Press `f5` to launch a new VSCode window with the extension installed
+- Press `CMD` + `R` to reload the window after having made any changes

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019  HubSpot, Inc.
+Copyright 2020  HubSpot, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,12 @@
-MIT License
+Copyright 2019  HubSpot, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Copyright (c) 2018 William Spiro
+   http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # HubL Visual Studio Code Language Extension
-Get it :point_right: https://marketplace.visualstudio.com/items?itemName=HubSpot.hubl
+This is the HubSpot extension for [Visual Studio Code](https://code.visualstudio.com/), allowing for :rocket: fast HubSpot CMS Hub development.
 
-Check out how to get started with local development on the HubSpot CMS :point_right: https://designers.hubspot.com/docs/tools/local-development
+This extension currently supports:
+- Syntax highlighting for the [HubL templating language](https://designers.hubspot.com/docs/hubl/intro-to-hubl)
+- Autocomlete for common HubL tags, filters, and functions
+- Bracket wrapping, indentation, and other helpful editor features
 
-[HubL](https://designers.hubspot.com/docs/hubl/intro-to-hubl) is the underlying syntax used in the [HubSpot content management system](https://www.hubspot.com/products/marketing/content-management-system). HubL can be used to dynamically render content, as well as generate easy to edit modules within the content editors marketers work in so they do not ever need to touch the underlying HTML of a template. This allows for many pages to use a single template, making managing content and websites significantly easier and quicker.
-
-This is a HubL language extension for the [Visual Studio Code IDE](https://code.visualstudio.com/), allowing for :rocket: fast local HubSpot CMS Platform development in `.html` files. For comprehensive HubL documentation, see the [HubL docs](https://designers.hubspot.com/docs/hubl/intro-to-hubl).
-
-Most HubL snippets are auto-generated from `@JinjavaDoc` annotations to ensure the snippets are always up to date, and easy to maintain :potable_water:
-
-![language extention demo](https://cdn2.hubspot.net/hubfs/2359872/IMPORTANT/DONOTDELETE/hubl-language-extension/nifty_gif.gif)
-_For nice HubL syntax highlighting, install the [Jinja scopes extension](https://marketplace.visualstudio.com/items?itemName=wholroyd.jinja) which lays on top of `.html` files._
+If you're new to CMS Hub, check out how to [get started with local development.](https://designers.hubspot.com/docs/tools/local-development)
 
 ## Features
+
+### Syntax Highlighting
+HubL syntax hightlighting is supported for `.HTML`, `.CSS`, and `.JS` files. To enable syntax highlighting, make sure that your file type is set to one of these types.
+
+_Thanks to the [Better Jinja](https://github.com/samuelcolvin/jinjahtml-vscode) extension for inspiration._
+
+### Editor Features
+- Statement wrapping (Supports `{%%}`,`{##}`,`{{}}`)
+- Block comment toggling: Press `CMD + /` to create HubL comments
+- Block level indentation: Text inside of `{% block %}` will be indented automatically
+
 ### __HubL Snippets__
 All HubL supported tags, filters, expression tests and functions have auto-complete snippets. Expression tests are accessed by typing the test name alone, filters are accessed with `|` and functions/tags are accessed with `~`. All snippets include descriptions and parameter details. You up/down arrow to navigate the IntelliSense and hit enter to execute a snippet. Snippet completed HubL statements will auto-highlight available parameters, which can be tabbed through (`${parameter}`).
 
@@ -151,24 +158,4 @@ group.repeater
 ```
 all associated fields need to be added into the children array within the snippet output
 
-
-
 _NOTE_: If you are having trouble getting IntelliSense suggestions when in snippet placeholders you may need to add the following to your [User Settings](https://code.visualstudio.com/docs/getstarted/settings) `"editor.suggest.snippetsPreventQuickSuggestions": false`. If parameter suggestions are not showing up, set `"editor.parameterHints": true`.
-
-### Editor Features
-This plugin adds support for auto completion of all HubL statement types and supports HubL statement swrapping (Supports `{%%}`,`{##}`,`{{}}`). Additionally, makes commenting (CMD + /) create HubL comments.
-
-### Syntax Highlighting
-HubL syntax hightlighting is supported for HTML, CSS, and JS files. Thanks to the [Better Jinja](https://github.com/samuelcolvin/jinjahtml-vscode) extension for inspiration.
-
-## Contributing
-Anyone should feel free to fork/PR this. Open source for the win!
-Please make sure and explain your changes thoroughly, update version and changelog where needed.
-
-_NOTE_: HubL tags, functions, expression tests and filters are all pulled from the `cos-rendering/v1/hubldoc` api, so do not update any `snippets/auto-gen/...` json files manually. Run `npm run generate` to re-generate these JSON files when HubL changes occur. `snippets/man_gen/...` files are for any extra/helpful snippets used in HubL - these files are maintained manually.
-
-To run locally:
-- `git clone` repo
-- Open this project in Visual Studio Code
-- Press `f5` to launch a new VSCode window with the extension installed
-- Press `CMD` + `R` to reload the window after having made any changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HubL Visual Studio Code Language Extension
-Get it :point_right: https://marketplace.visualstudio.com/items?itemName=WilliamSpiro.hubl
+Get it :point_right: https://marketplace.visualstudio.com/items?itemName=HubSpot.hubl
 
 Check out how to get started with local development on the HubSpot CMS :point_right: https://designers.hubspot.com/docs/tools/local-development
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,6 @@ This plugin adds support for auto completion of all HubL statement types and sup
 ### Syntax Highlighting
 HubL syntax hightlighting is supported for HTML, CSS, and JS files. Thanks to the [Better Jinja](https://github.com/samuelcolvin/jinjahtml-vscode) extension for inspiration.
 
-## License
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-
 ## Contributing
 Anyone should feel free to fork/PR this. Open source for the win!
 Please make sure and explain your changes thoroughly, update version and changelog where needed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "hubl",
-    "displayName": "HubL Language Extension",
-    "description": "HubL Visual Studio Code Language Extension",
+    "displayName": "HubSpot VS Code Extension",
+    "description": "HubSpot CMS Hub support for VS Code",
     "version": "0.2.0",
     "publisher": "HubSpot",
     "engines": {
@@ -14,9 +14,9 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/HubSpot/HubL-Language-Extension"
+        "url": "https://github.com/HubSpot/hubspot-cms-vscode"
     },
-    "homepage": "https://github.com/HubSpot/HubL-Language-Extension/blob/master/README.md",
+    "homepage": "https://github.com/HubSpot/hubspot-cms-vscode/blob/master/README.md",
     "categories": [
         "Snippets"
     ],

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "hubl",
     "displayName": "HubL Language Extension",
     "description": "HubL Visual Studio Code Language Extension",
-    "version": "0.1.4",
-    "publisher": "WilliamSpiro",
+    "version": "0.2.0",
+    "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.30.0"
     },
@@ -14,9 +14,9 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/williamspiro/HubL-Language-Extension"
+        "url": "https://github.com/HubSpot/HubL-Language-Extension"
     },
-    "homepage": "https://github.com/williamspiro/HubL-Language-Extension/blob/master/README.md",
+    "homepage": "https://github.com/HubSpot/HubL-Language-Extension/blob/master/README.md",
     "categories": [
         "Snippets"
     ],


### PR DESCRIPTION
After merging, we'll need to:
- update this repo name (to `hubspot-cms-vscode`)
- build/publish the [extension to the marketplace](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)

Resolves #58 
Resolves #46 