### PR TITLE
chore(settings): vscode settings got changed to editor.parameterHints.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you would like to get IntelliSense suggestions when in snippet placeholders, 
 
 For parameter suggestions, the following should also be added:
 
-`"editor.parameterHints": true`
+`"editor.parameterHints.enabled": true`
 
 ## Telemetry
 


### PR DESCRIPTION
### What?

`editor.parameterHints` got renamed as  `editor.parameterHints.enabled`
