### PR TITLE
Add a get started link for project dev

### DIFF
--- a/src/lib/providers/treedata/helpAndFeedback.ts
+++ b/src/lib/providers/treedata/helpAndFeedback.ts
@@ -23,6 +23,10 @@ export class HelpAndFeedbackProvider implements TreeDataProvider<any> {
   getChildren(): Thenable<Array<Link | Command>> {
     return Promise.resolve([
       {
+        label: 'Get started with HubSpot development',
+        url: 'https://developers.hubspot.com/docs/getting-started/quickstart',
+      },
+      {
         label: 'CLI Documentation',
         url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#interacting-with-the-developer-file-system',
       },


### PR DESCRIPTION
Add a link to the getting started page in the hubspot dev docs

<img width="315" height="297" alt="image" src="https://github.com/user-attachments/assets/1ac96e1a-3f60-4010-8f6d-319887c50f9d" />
