### PR TITLE
Remove environment from tooltip & fix local config issue

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { commands, window } from 'vscode';
 import { COMMANDS, EVENTS } from './constants';
 import {
+  configFileExists,
   findConfig,
   loadConfig,
   validateConfig,
@@ -30,7 +31,13 @@ export const loadHubspotConfigFile = (rootPath: string) => {
   }
 
   const deprecatedConfigPath = findConfig(rootPath);
-  const globalConfigPath = getConfigPath(undefined, true);
+  const globalConfigExists = configFileExists(true);
+
+  let globalConfigPath: string | null = null;
+
+  if (globalConfigExists) {
+    globalConfigPath = getConfigPath(undefined, true);
+  }
 
   const resolvedConfigPath = globalConfigPath || deprecatedConfigPath;
 

--- a/src/lib/providers/treedata/accounts.ts
+++ b/src/lib/providers/treedata/accounts.ts
@@ -11,6 +11,7 @@ import {
   getConfigAccounts,
   getConfigDefaultAccount,
 } from '@hubspot/local-dev-lib/config';
+import { ENVIRONMENTS } from '@hubspot/local-dev-lib/constants/environments';
 import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { CLIConfig } from '@hubspot/local-dev-lib/types/Config';
 import {
@@ -44,8 +45,10 @@ export class AccountsProvider
   implements TreeDataProvider<CLIAccount_DEPRECATED>
 {
   private config: CLIConfig | null;
+  private hasAnyQAAccounts: boolean;
   constructor() {
     this.config = getConfig();
+    this.hasAnyQAAccounts = false;
   }
 
   _onDidChangeTreeData: EventEmitter<undefined> = new EventEmitter<undefined>();
@@ -62,7 +65,10 @@ export class AccountsProvider
     return new AccountTreeItem(
       name,
       p,
-      { isDefault: isDefaultAccount(p, this.config) ?? false },
+      {
+        isDefault: isDefaultAccount(p, this.config) ?? false,
+        hasAnyQAAccounts: this.hasAnyQAAccounts,
+      },
       TreeItemCollapsibleState.None
     );
   }
@@ -73,9 +79,14 @@ export class AccountsProvider
     const accounts = getConfigAccounts();
 
     if (accounts) {
+      this.hasAnyQAAccounts = accounts.some(
+        (account) => account.env === ENVIRONMENTS.QA
+      );
+
       return Promise.resolve(accounts);
     }
 
+    this.hasAnyQAAccounts = false;
     return Promise.resolve([]);
   }
 }
@@ -84,20 +95,17 @@ export class AccountTreeItem extends TreeItem {
   constructor(
     public readonly name: string,
     public readonly portalData: CLIAccount_DEPRECATED,
-    public readonly options: { isDefault: boolean },
-    public readonly collapsibleState: TreeItemCollapsibleState,
-    public iconPath: ThemeIcon = new ThemeIcon('account'),
-    public readonly contextValue: string = 'accountTreeItem'
+    public readonly options: { isDefault: boolean; hasAnyQAAccounts: boolean },
+    public readonly collapsibleState: TreeItemCollapsibleState
   ) {
     super(name, collapsibleState);
 
-    if (options.isDefault) {
-      this.iconPath = new ThemeIcon('star-full');
-    }
+    this.contextValue = 'accountTreeItem';
+    this.iconPath = new ThemeIcon(options.isDefault ? 'star-full' : 'account');
     this.tooltip = `${options.isDefault ? '* Default Account\n' : ''}${
       portalData.name ? `Name: ${portalData.name}\n` : ''
     }ID: ${getAccountIdentifier(portalData)}\n${
-      portalData.env ? `Environment: ${portalData.env}\n` : ''
+      options.hasAnyQAAccounts ? `Environment: ${portalData.env}\n` : ''
     }${
       portalData.sandboxAccountType
         ? `Sandbox Account Type: ${portalData.sandboxAccountType}`


### PR DESCRIPTION
We should only show the "environment" label in the account tooltip (shows when you hover over an account name in the "Accounts" section) if the user actually has QA accounts configured. This mostly has internal value since external customers can't have qa accounts.

This also fixes a bug for users who are using the hubspot.config.yml files instead of global config and do not want to migrate. We were always showing the migration prompt, regardless of whether the user had an existing global config or not.