### PR TITLE
Add new file picker fields for Video, Document, and Audio in custom m…

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -309,6 +309,54 @@
     ],
     "description": "HubSpot File"
   },
+  "Video Field": {
+    "prefix": "field.video",
+    "body": [
+      "{",
+      "\"picker\": \"video\",",
+      "\"name\": \"${1:file_field}\",",
+      "\"label\": \"${2:File field}\",",
+      "\"required\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"locked\": false,",
+      "\"type\": \"file\",",
+      "\"default\": null }"
+    ],
+    "description": "HubSpot File - Picker Video"
+  },
+  "Document Field": {
+    "prefix": "field.document",
+    "body": [
+      "{",
+      "\"picker\": \"document\",",
+      "\"name\": \"${1:file_field}\",",
+      "\"label\": \"${2:File field}\",",
+      "\"required\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"locked\": false,",
+      "\"type\": \"file\",",
+      "\"default\": null }"
+    ],
+    "description": "HubSpot File - Picker Document"
+  },
+  "Audio Field": {
+    "prefix": "field.audio",
+    "body": [
+      "{",
+      "\"picker\": \"audio\",",
+      "\"name\": \"${1:file_field}\",",
+      "\"label\": \"${2:File field}\",",
+      "\"required\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"locked\": false,",
+      "\"type\": \"file\",",
+      "\"default\": null }"
+    ],
+    "description": "HubSpot File - Picker Audio"
+  },
   "Followup Email Field": {
     "prefix": "field.followup",
     "body": [


### PR DESCRIPTION
### Summary
This pull request adds new snippet templates to the `hubl_custom_module_fields.json` file to support additional HubSpot file picker field types. These new snippets make it easier to insert video, document, and audio file picker fields when building custom modules.

**New HubSpot file picker field snippets:**

* Added a `Video Field` snippet for inserting a file field with a video picker (`field.video`).
* Added a `Document Field` snippet for inserting a file field with a document picker (`field.document`).
* Added an `Audio Field` snippet for inserting a file field with an audio picker (`field.audio`).

### Motivatiom
I’m a HubSpot CMS developer, and I introduced this change to speed up my daily development workflow.
With these changes, now it is easier and faster to create new file fields that accept only certain files.