### PR TITLE
fix: rename table_id to table_name_or_id in HubDB Row Field snippet t…

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -417,7 +417,7 @@
       "\"label\": \"${2:HubDB Row field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"table_id\": ${3:null},",
+      "\"table_name_or_id\": ${3:null},",
       "\"type\": \"hubdbrow\",",
       "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",


### PR DESCRIPTION
This pull request makes a minor update to the `snippets/man_gen/hubl_custom_module_fields.json` file, renaming a property for clarity and accuracy.

- Field name update:
  * Changed the property from `table_id` to `table_name_or_id` to follow the documentation: https://developers.hubspot.com/docs/cms/reference/fields/module-theme-fields#hubdb-row