### PR TITLE
fix: Setting properties on hsStatusBar before checking if it is defined

### DIFF
--- a/src/features/statusBar.ts
+++ b/src/features/statusBar.ts
@@ -14,6 +14,10 @@ import {
 let hsStatusBar: StatusBarItem;
 
 export const updateStatusBarItems = () => {
+  if(!hsStatusBar) {
+    return;
+  }
+
   const config = getConfig();
   const defaultAccount = config && getConfigDefaultAccountIfExists();
 

--- a/src/features/statusBar.ts
+++ b/src/features/statusBar.ts
@@ -14,7 +14,7 @@ import {
 let hsStatusBar: StatusBarItem;
 
 export const updateStatusBarItems = () => {
-  if(!hsStatusBar) {
+  if (!hsStatusBar) {
     return;
   }
 


### PR DESCRIPTION
## Description and Context

<!-- Provide a summary of what has changed -->
<!-- Provide links to relevant discussions or documentation to promote understanding and addressing this PR -->
<!-- Describe any packages you'd like to add and the reasons why. -->
Adds an early return to the `updateStatusBarItems` which was logging errors about trying to set a property on an undefined object.

## Screenshots

<!-- Provide images of the before and after functionality -->
<img width="702" height="44" alt="image" src="https://github.com/user-attachments/assets/d2d0ea70-416d-41e8-8068-d47f67085b12" />

