### PR TITLE
chore: Remove chiragchadha1 as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brandenrodgers @camden11 @joe-yeager @chiragchadha1
+* @brandenrodgers @camden11 @joe-yeager


### PR DESCRIPTION
## Summary
- Removes `@chiragchadha1` from `.github/CODEOWNERS`